### PR TITLE
Add parameter to enable debug output for webhooks

### DIFF
--- a/config/parameters.test.yml
+++ b/config/parameters.test.yml
@@ -4,3 +4,4 @@ parameters:
     satis_filename: "vfs://root/satis.json"
     satis_log_path: "vfs://root/satis/"
     admin.auth: false
+    webhook.debug: false

--- a/config/parameters.yml.dist
+++ b/config/parameters.yml.dist
@@ -6,3 +6,4 @@ parameters:
     admin.users: []
     composer.home: "%env(resolve:COMPOSER_HOME)%"
     composer.cache: "%env(resolve:COMPOSER_CACHE)%"
+    webhook.debug: false

--- a/src/Playbloom/Satisfy/Event/BuildEvent.php
+++ b/src/Playbloom/Satisfy/Event/BuildEvent.php
@@ -2,6 +2,7 @@
 
 namespace Playbloom\Satisfy\Event;
 
+use Playbloom\Satisfy\Model\BuildContext;
 use Playbloom\Satisfy\Model\RepositoryInterface;
 use Symfony\Contracts\EventDispatcher\Event;
 
@@ -14,6 +15,8 @@ class BuildEvent extends Event
 
     /** @var int|null */
     private $status;
+
+    private ?BuildContext $context;
 
     public function __construct(?RepositoryInterface $repository = null)
     {
@@ -39,5 +42,15 @@ class BuildEvent extends Event
     public function setStatus(int $status)
     {
         $this->status = $status;
+    }
+
+    public function getContext(): ?BuildContext
+    {
+        return $this->context;
+    }
+
+    public function setContext(BuildContext $context): void
+    {
+        $this->context = $context;
     }
 }

--- a/src/Playbloom/Satisfy/Model/BuildContext.php
+++ b/src/Playbloom/Satisfy/Model/BuildContext.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Playbloom\Satisfy\Model;
+
+class BuildContext
+{
+    private int $exitCode;
+    private string $command;
+    private string $output;
+    private string $errorOutput;
+    private ?\Throwable $throwable;
+
+    public function __construct(int $exitCode, string $command, string $output, string $errorOutput, ?\Throwable $throwable = null)
+    {
+        $this->exitCode = $exitCode;
+        $this->command = $command;
+        $this->output = $output;
+        $this->errorOutput = $errorOutput;
+        $this->throwable = $throwable;
+    }
+
+    public function getExitCode(): int
+    {
+        return $this->exitCode;
+    }
+
+    public function getCommand(): string
+    {
+        return $this->command;
+    }
+
+    public function getOutput(): string
+    {
+        return $this->output;
+    }
+
+    public function getErrorOutput(): string
+    {
+        return $this->errorOutput;
+    }
+
+    public function getThrowable(): ?\Throwable
+    {
+        return $this->throwable;
+    }
+}

--- a/src/Playbloom/Satisfy/Resources/config/services.yml
+++ b/src/Playbloom/Satisfy/Resources/config/services.yml
@@ -79,10 +79,13 @@ services:
   ### Webhook handlers
   Playbloom\Satisfy\Webhook\BitbucketWebhook:
     public: true
+    calls:
+      - [ setDebug, [ "%webhook.debug%" ] ]
 
   Playbloom\Satisfy\Webhook\GithubWebhook:
     public: true
     calls:
+      - [setDebug, ["%webhook.debug%"]]
       - [setSecret, ["%github.secret%"]]
       - [setSourceUrls, ["%github.source_urls%"]]
       - [setAutoAdd, ["%github.auto_add_repo%"]]
@@ -91,6 +94,7 @@ services:
   Playbloom\Satisfy\Webhook\GiteaWebhook:
     public: true
     calls:
+      - [setDebug, ["%webhook.debug%"]]
       - [setSecret, ["%gitea.secret%"]]
       - [setSourceUrls, ["%gitea.source_urls%"]]
       - [setAutoAdd, ["%gitea.auto_add_repo%"]]
@@ -103,6 +107,8 @@ services:
       $autoAdd: "%gitlab.auto_add_repo%"
       $autoAddType: "%gitlab.auto_add_repo_type%"
       $preferSshUrlType: "%gitlab.prefer_ssh_url_type%"
+    calls:
+      - [setDebug, ["%webhook.debug%"]]
 
   Playbloom\Satisfy\Validator\EnvValidator:
     public: true
@@ -110,9 +116,13 @@ services:
       $root: "%kernel.project_dir%"
       $satisFilename: "%satis_filename%"
       $composerHome: "%composer.home%"
+    calls:
+      - [setDebug, ["%webhook.debug%"]]
 
   Playbloom\Satisfy\Webhook\DevOpsWebhook:
     autowire: true
     public: true
     arguments:
       $secret: "%devops.secret%"
+    calls:
+      - [setDebug, ["%webhook.debug%"]]

--- a/src/Playbloom/Satisfy/Runner/SatisBuildRunner.php
+++ b/src/Playbloom/Satisfy/Runner/SatisBuildRunner.php
@@ -3,6 +3,7 @@
 namespace Playbloom\Satisfy\Runner;
 
 use Playbloom\Satisfy\Event\BuildEvent;
+use Playbloom\Satisfy\Model\BuildContext;
 use Playbloom\Satisfy\Process\ProcessFactory;
 use Playbloom\Satisfy\Service\Manager;
 use Symfony\Component\Lock\LockInterface;
@@ -70,13 +71,22 @@ class SatisBuildRunner
         try {
             $this->lock->acquire(true);
             $status = $process->run();
+            $exception = null;
         } catch (RuntimeException $exception) {
             $status = 1;
         } finally {
             $this->lock->release();
+            $context = new BuildContext(
+                $process->getExitCode(),
+                $process->getCommandLine(),
+                $process->getOutput(),
+                $process->getErrorOutput(),
+                $exception,
+            );
         }
 
         $event->setStatus($status);
+        $event->setContext($context);
     }
 
     /**


### PR DESCRIPTION
I notice frequent 500 on my webhooks and I have a hard time figure out why. Of course, I should follow up this PR to add logs. But it seams like we dont want to use LoggerInterface in this repo. Not sure why but I will be happy to add some logs. 

This PR introduces a `BuildContext` that is passed up to the `AbstractWebhook`. If debug is enabled, we will output a nice content to our HTTP Response. 