### PR TITLE
fix: add safe.directory configuration for git in Dockerfile

### DIFF
--- a/docker/php/Dockerfile
+++ b/docker/php/Dockerfile
@@ -13,6 +13,8 @@ COPY php.ini /usr/local/etc/php/conf.d/satisfy.ini
 
 USER www-data
 RUN mkdir -p ~/.ssh && chmod 0700 ~/.ssh && ssh-keyscan -H github.com >> ~/.ssh/known_hosts && \
-    mkdir -p ~/.composer && chown www-data:www-data ~/.composer
+    mkdir -p ~/.composer && chown www-data:www-data ~/.composer && \
+    git config --global --add safe.directory /var/www/html
 
 USER root
+RUN git config --system --add safe.directory /var/www/html


### PR DESCRIPTION
Fixes the following errro:
```
'/var/www/html/bin/satis' 'build' '/var/www/html/satis.json' 'public' '--skip-errors' '--no-ansi' '--verbose'
The repository at "/var/www/html" does not have the correct ownership and git refuses to use it:
In Git.php line 54:
Exception trace:
Composer\Console\Application->doRun() at /var/www/html/vendor/composer/satis/src/Console/Application.php:62
Composer\Console\Application->run() at /var/www/html/vendor/composer/satis/bin/satis:71
build [--repository-url REPOSITORY-URL] [--repository-strict] [--no-html-output] [--skip-errors] [--stats] [--minify] [--] [ [ [...]]]
General error
```
It happens when you're trying to build the packages, using the own baked image from dockerfile